### PR TITLE
feat!: change label_selector from string to dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,41 +59,45 @@ Description of the snapshot/backup.
 #### Default value
 
 ```yaml
-backup_description: "{{ inventory_hostname }} {{ now(fmt='%Y-%m-%d-%H:%M:%S') }}"
+backup_description: "{{ inventory_hostname }} {{ now(fmt='%Y-%m-%d %H:%M:%S') }}"
 ```
 
 ### backup_labels
 
 List of labels of the snapshot/backup.
-Format: `key: "value"`
+Format: `key: "value"` or `key: ""`  for labels without a value.
 
 #### Default value
 
 ```yaml
 backup_labels:
-  created_by: "ansible.hcloud-backup"
-  host: "{{ inventory_hostname }}"
-  created_at: "{{ now(fmt='%Y-%m-%d_%H-%M-%S') }}"
+    created_by: "ansible.hcloud-backup"
+    created_at: "{{ now(fmt='%Y-%m-%d_%H-%M-%S') }}"
+    host: "{{ inventory_hostname }}"
+    rotation: "true"
 ```
 
 ### label_selector
 
-Labels to identify a snapshots for rotation, should overlap with [`backup_labels`](#backup_labels).
+List of labels to identify snapshots for rotation, should overlap with [`backup_labels`](#backup_labels).
 
 Only used when [`backup_type`](#backup_type) is set to `snapshot`.
 
-Format: `key=value` or `key`, separate multiple labels with a comma: `key1=value1,key2=value2`
+Format: `key: "value"` or `key: ""` for labels without a value
 
 #### Default value
 
 ```yaml
-label_selector: "created_by=ansible.hcloud-backup,host={{ inventory_hostname }}"
+label_selector:
+    created_by: ansible.hcloud-backup
+    host: "{{ inventory_hostname }}"
+    rotation: "true"
 ```
 
 ### rotate_snapshots
 
-Rotate snapshots, if set to `true`, the oldest snapshot(s) will be deleted based
-depending on the [`keep_snapshots`](#keep_snapshots) variable.
+Rotate snapshots, if set to `true`, the oldest found snapshot(s) will be deleted
+depending on the [`keep_snapshots`](#keep_snapshots) variable and the number of existing snapshots.
 
 Only used when [`backup_type`](#backup_type) is set to `snapshot`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,16 +8,20 @@ backup_type: 'snapshot'
 backup_description: "{{ inventory_hostname }} {{ now(fmt='%Y-%m-%d %H:%M:%S') }}"
 
 # List of labels of the snapshot/backup
-# Format: key: "value"
+# Format: key: "value" or key: "" for labels without a value
 backup_labels:
   created_by: "ansible.hcloud-backup"
-  host: "{{ inventory_hostname }}"
   created_at: "{{ now(fmt='%Y-%m-%d_%H-%M-%S') }}"
+  host: "{{ inventory_hostname }}"
+  rotation: "true"
 
-# Labels to identify a snapshots for rotation, should overlap with backup_labels
+# List of labels to identify snapshots for rotation, should overlap with backup_labels
 # Only used when backup_type is set to 'snapshot'
-# Format: 'key=value' or 'key', separate multiple labels with a comma
-label_selector: "created_by=ansible.hcloud-backup,host={{ inventory_hostname }}"
+# Format: key: "value" or key: "" for labels without a value
+label_selector:
+  created_by: ansible.hcloud-backup
+  host: "{{ inventory_hostname }}"
+  rotation: "true"
 
 # Rotate snapshots, if set to true, the oldest snapshot will be deleted
 # when the number of snapshots exceeds keep_snapshots.

--- a/tasks/rotate-snapshots.yml
+++ b/tasks/rotate-snapshots.yml
@@ -1,14 +1,14 @@
 ---
-- name: 'Get all snapshots with labels: "{{ label_selector }}"'
+- name: 'Gather all snapshots with labels: "{{ label_selector }}"'
   delegate_to: "{{ delegation }}"
   register: response
   hetzner.hcloud.hcloud_image_info:
     api_token: "{{ api_token }}"
     type: snapshot
-    label_selector: "{{ label_selector }}"
+    label_selector: "{{ label_selector | items | map('join', '=') | join(',') }}"
   failed_when: response.hcloud_image_info | length == 0
 
-- name: Get snapshots to delete for {{ inventory_hostname }}
+- name: Gather snapshots to delete for {{ inventory_hostname }}
   delegate_to: "{{ delegation }}"
   set_fact:
     delete_list: "{{ response.hcloud_image_info[0:response.hcloud_image_info | length - keep_snapshots | int] }}"

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -50,33 +50,37 @@
       - item.value is string
       - item.key != ""
       - item.key is match("^[a-zA-Z0-9_\-\.]+$")
-      - item.value is match("^[a-zA-Z0-9_\-\.]+$")
+      - item.value is match("^[a-zA-Z0-9_\-\.]+$") or item.value == ""
       - item.key | length < 64
       - item.value | length < 64
-    fail_msg: "Label key or value not in correct format."
+    fail_msg: "Label not in correct format."
 
-- name: Validate label selector
+- name: Validate label selectors
   delegate_to: "{{ delegation }}"
   when: backup_type == "snapshot"
+  loop: "{{ label_selector | dict2items }}"
   assert:
     quiet: yes
     that:
-      - label_selector is string
-      # Regex for label selector format: key=value or key, separate multiple labels with a comma
-      - label_selector is match("^([a-zA-Z0-9_\-\.]+=[a-zA-Z0-9_\-\.]+)(,[a-zA-Z0-9_\-\.]+=[a-zA-Z0-9_\-\.]+)*$")
+      - item.key is string
+      - item.value is string
+      - item.key != ""
+      - item.key is match("^[a-zA-Z0-9_\-\.]+$")
+      - item.value is match("^[a-zA-Z0-9_\-\.]+$")
+      - item.key | length < 64
+      - item.value | length < 64
     fail_msg: "Label selector not in correct format."
 
 - name: Validate if labels in label_selector are also in backup_labels
   delegate_to: "{{ delegation }}"
   when: backup_type == "snapshot"
+  loop: "{{ label_selector | dict2items }}"
   assert:
     quiet: yes
     that:
-      - label_selector.split(",") | map("split", "=") | map("first") | list | difference(backup_labels.keys() | list) == []
-      - label_selector.split(",") | map("split", "=") | map("first") | list | difference(backup_labels.keys() | list) | length == 0
-      - label_selector.split(",") | map("split", "=") | map("last") | list | difference(backup_labels.values() | list) == []
-      - label_selector.split(",") | map("split", "=") | map("last") | list | difference(backup_labels.values() | list) | length == 0
-    fail_msg: "label_selector contains labels that are not in backup_labels variable."
+      - item.key in backup_labels.keys()
+      - item.value == backup_labels[item.key]
+    fail_msg: "Could not find label_selector in backup_labels."
 
 - name: Check if backups are enabled on server
   when: backup_type == "backup"


### PR DESCRIPTION
# Breaking Change

This changes the `label_selector` variable type from string to dictionary to simplify managing the labels to search/filter for on rotation.

## Example

Before:
```yaml
label_selector: "created_by=ansible.hcloud-backup,host={{ inventory_hostname }}"
```

Now:
```yaml
label_selector:
  created_by: ansible.hcloud-backup
  host: "{{ inventory_hostname }}"
```